### PR TITLE
Dev coerse dt errors

### DIFF
--- a/server_cabinets_25c.cfg
+++ b/server_cabinets_25c.cfg
@@ -19,35 +19,21 @@ description = Geb.25C Curing Cabinets
 verbose = 1
 
 # daf
-thermorasps = rasp3-bus1-ch1 rasp3-bus4-ch1 rasp3-bus4-ch0 rasp3-bus3-ch1
+thermorasps = rasp15-bus1-ch0 rasp15-bus1-ch1
 
 [storage]
 path = curing-cabinets
 
-[rasp3-bus1-ch1]
-host = fhlthermorasp3.desy.de
-port = 50008
-name = cabinet2_bme680-top
-description = RaspPi with meters
-updateInterval = 60 
-
-[rasp3-bus4-ch1]
-host = fhlthermorasp3.desy.de
-port = 50009
-name = cabinet2_bme680-middle
-description = RaspPi with meters
-updateInterval = 60 
-
-[rasp3-bus4-ch0]
-host = fhlthermorasp3.desy.de
+[rasp15-bus1-ch0]
+host = fhlthermorasp15.desy.de
 port = 50010
-name = cabinet2_bme680-bottom
+name = cabinet2_bme680-2
 description = RaspPi with meters
 updateInterval = 60 
 
-[rasp3-bus3-ch1]
-host = fhlthermorasp3.desy.de
+[rasp15-bus1-ch1]
+host = fhlthermorasp15.desy.de
 port = 50011
-name = cabinet2_bme680-extra
+name = cabinet2_bme680-1
 description = RaspPi with meters
 updateInterval = 60 

--- a/www/curing-cabinets-environment/main.py
+++ b/www/curing-cabinets-environment/main.py
@@ -57,6 +57,12 @@ import numpy as np
 
 global periodic_callback_id
 
+def h_space():
+    return PreText(text="", width=50, height=1)
+
+def v_space():
+    return PreText(text="", width=1, height=50)
+
 def dew_point(t,rh):
 # refs:
 # https://iridl.ldeo.columbia.edu/dochelp/QA/Basic/dewpoint.html
@@ -173,7 +179,12 @@ def readdata():
             sdata[sensor[l]] = pd.read_csv(mycsv,names=("datetime","temperature","pressure","humidity"),parse_dates=[0],comment='#',header=0)
         else:
             sdata[sensor[l]] = pd.read_csv(mycsv,names=("datetime","temperature"),parse_dates=[0],comment='#',header=0)
-            
+        
+        # Force datetime parsing, coerce bad ones to NaT
+        sdata[sensor[l]]['datetime'] = pd.to_datetime(sdata[sensor[l]]['datetime'], errors='coerce')
+        # Drop bad datetime rows
+        sdata[sensor[l]] = sdata[sensor[l]].dropna(subset=['datetime'])
+
         if l == 'outside':
             sdata[sensor[l]]['datetime'] = sdata[sensor[l]].datetime.dt.tz_localize('Europe/Berlin',ambiguous='infer')
         else:
@@ -229,7 +240,7 @@ if __name__ == "__main__" :
     main ()
     
 elif __name__.startswith('bokeh_app') or __name__.startswith('bk_script'):
-    date_format = ['%d %b %Y %H:%M:%S']
+    date_format = '%d %b %Y %H:%M:%S'
     # name starts with bk_script (__name__ = bk_script_<some number>)
     
     # read data from the files
@@ -328,11 +339,11 @@ elif __name__.startswith('bokeh_app') or __name__.startswith('bk_script'):
     pre_temp_mid = PreText(text="",width=400, height=20)
     pre_temp_bot = PreText(text="",width=400, height=20)
     
-    h_space = PreText(text="",width=50, height=1)
-    v_space = PreText(text="",width=1, height=50)
+    # h_space = PreText(text="",width=50, height=1)
+    # v_space = PreText(text="",width=1, height=50)
     
     
-    curdoc().add_root(column(row(h_space,pre_head),row(h_space, date_picker_i, date_picker_f), row(h_space, hist_button),v_space,row(h_space,plot['dewpoint'],h_space,plot['temperature']), v_space,row(h_space,plot['humidity'],h_space,plot['pressure']), v_space))
+    curdoc().add_root(column(row(h_space(),pre_head),row(h_space(), date_picker_i, date_picker_f), row(h_space(), hist_button),v_space(),row(h_space(),plot['dewpoint'],h_space(),plot['temperature']), v_space(),row(h_space(),plot['humidity'],h_space(),plot['pressure']), v_space()))
     
 #    readdata()
 #    main()


### PR DESCRIPTION
Data corrupted
- Fixed: Can only use .dt accessor with datetime like values 
- Improved: BokehDeprecationWarning: Passing lists of formats for DatetimeTickFormatter scales was deprecated in Bokeh 3.0. Configure a single string format for each scale
- Improved: E-1027 (REPEATED_LAYOUT_CHILD): The same model can't be used multiple times in a layout: Row(id='p1350', ...)
